### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/stickemballe/Bot-DWS75-secu/security/code-scanning/1](https://github.com/stickemballe/Bot-DWS75-secu/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions. Since the workflow only checks out code and runs tests, it does not require write access to repository contents or other resources. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file, just below the `name:` key and above the `on:` key. This will apply the least privilege to all jobs in the workflow unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
